### PR TITLE
removing prometheus nsq alert (moved to grafana)

### DIFF
--- a/nsq/values.yaml
+++ b/nsq/values.yaml
@@ -32,13 +32,6 @@ serviceMonitor:
     rules:
     - name: nsqd.rules
       rules:
-      - alert: NsqdChannelOverflow
-        annotations:
-          message: Channel {{`{{ $labels.channel }}`}} not clearing up with {{`{{ $value }}`}} messages in queue for 5 min.
-        expr: 'sum(nsq_channel_depth{topic=~"events|tasks|alerts", paused="false",job="nsqd"}) by (channel) > 0'
-        for: 5m
-        labels:
-          severity: critical
       - alert: NsqdTopicOverflow
         annotations:
           message: Topic {{`{{ $labels.topic }}`}} not clearing up with {{`{{ $value }}`}} messages in queue for 5 min.


### PR DESCRIPTION
New alert location: https://grafana.augury.com/d/Wlw2OZtMk/backend-services-alerts?tab=alert&panelId=10&edit&fullscreen&orgId=1&from=1611739848410&to=1611739884235